### PR TITLE
Use fetch instead of node-fetch

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -7,7 +7,6 @@
 
 const { forEach } = require('lodash');
 const NodeHelper = require('node_helper');
-const fetch = require('node-fetch');
 const sampleJson = require('./json_response.json');
 const Log = require("logger");
 


### PR DESCRIPTION
`node-fetch` isn't necessary for this, and is causing issues with ease of installation. Using `fetch` instead yields the same results but works without additional installation settings.